### PR TITLE
Fix dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,24 +4,22 @@ authors = ["@alvaro1101, Rob J Goedman <goedman@icloud.com>, Chris Fisher"]
 version = "0.1.0"
 
 [deps]
-CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
+
+[compat]
+RecipesBase = "1"
+StatsFuns = "0.9"
+julia = "1"
+
+[extras]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StanSample = "c1514b29-d3a0-5178-b312-660c88baa699"
-Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
-StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[compat]
-CSV = "0.8"
-DataFrames = "0.22"
-Distributions = "0.24"
-JSON = "0.21"
-StanSample = "3.0"
-StatsFuns = "0.9"
-StatsPlots = "0.14"
-julia = "1"
+[targets]
+test = ["JSON", "Printf", "Random", "StanSample", "Test"]

--- a/src/StatsModelComparisons.jl
+++ b/src/StatsModelComparisons.jl
@@ -43,20 +43,23 @@ arXiv preprint arXiv:1507.02646.
 
 module StatsModelComparisons
 
-    using StatsFuns, Statistics
+using RecipesBase
+using StatsFuns
+using Statistics
 
-    mc_path = @__DIR__
+const mc_path = @__DIR__
 
-    include("psisloo.jl")
-    include("psislw.jl")
-    include("gpdfitnew.jl")
-    include("gpinv.jl")
-    include("waic.jl")
-    include("pk_utilities.jl")
-    include("dic.jl")
-    include("legacy.jl")
+include("psisloo.jl")
+include("psislw.jl")
+include("gpdfitnew.jl")
+include("gpinv.jl")
+include("waic.jl")
+include("pk_utilities.jl")
+include("dic.jl")
+include("legacy.jl")
 
-    export mc_path, deviance, dic, psisloo, gpdfitnew, gpinv
-    export waic, aic, bic
-
+export mc_path, deviance, dic, psisloo, gpdfitnew, gpinv
+export var2, waic, aic, bic
+export psislw
+export pk_qualify
 end

--- a/src/StatsModelComparisons.jl
+++ b/src/StatsModelComparisons.jl
@@ -1,6 +1,7 @@
-"""StatsModelComparisons
+"""
+    StatsModelComparisons
 
-This module implements several model comparison methods such as PSIS, WAIC and DIC..
+This module implements several model comparison methods such as PSIS, WAIC and DIC.
 
 Included functions
 ------------------
@@ -40,7 +41,6 @@ models. arXiv preprint arXiv:1507.04544.
 Aki Vehtari and Andrew Gelman (2015). Pareto smoothed importance sampling.
 arXiv preprint arXiv:1507.02646.
 """
-
 module StatsModelComparisons
 
 using RecipesBase

--- a/src/dic.jl
+++ b/src/dic.jl
@@ -10,8 +10,10 @@ Computes Deviance Information Criterion (DIC).
 * `dic::Real`: DIC value
 """
 function dic(loglike::AbstractVector{<:Real})
-    D = deviance.(loglike)
-    return mean(D) + 0.5 * var(D)
+    D = map(deviance, loglike)
+    mean_D = mean(D)
+    var_D = var(D; mean=mean_D)
+    return mean_D + var_D / 2
 end
 
 deviance(loglikelihood::Real) = -2 * loglikelihood

--- a/src/dic.jl
+++ b/src/dic.jl
@@ -4,7 +4,7 @@
 Computes Deviance Information Criterion (DIC).
 
 # Arguments
-* `log_lik::AbstractArray`: A vector of posterior log likelihoods
+* `loglike::AbstractArray`: A vector of posterior log likelihoods
 
 # Returns
 * `dic::Real`: DIC value

--- a/src/pk_utilities.jl
+++ b/src/pk_utilities.jl
@@ -1,5 +1,3 @@
-using StatsPlots
-
 function pk_qualify(pk::Vector{Float64})
     pk_good = sum(pk .<= 0.5)
     pk_ok = length(pk[pk .<= 0.7]) - pk_good
@@ -7,15 +5,42 @@ function pk_qualify(pk::Vector{Float64})
     (good=pk_good, ok=pk_ok, bad=pk_bad, very_bad=sum(pk .> 1))
 end
 
-function pk_plot(pk::Vector{Float64}; title="PSIS diagnostic plot.",
-    leg=:topleft, kwargs...)
-    scatter(pk, xlab="Datapoint", ylab="Pareto shape k",
-        marker=2.5, lab="Pk points", leg=leg)
-  hline!([0.5], lab="pk = 0.5");hline!([0.7], lab="pk = 0.7")
-  hline!([1], lab="pk = 1.0")
-  title!(title)
-end
+@userplot Pk_Plot
 
-export
-    pk_qualify,
-    pk_plot
+@recipe function f(p::Pk_Plot)
+    if length(p.args) != 1 || !(p.args[1] isa AbstractVector{<:Real})
+        error("PSIS diagnostic plots should be given one vector. Got: ", typeof(p.args))
+    end
+    pk = p.args[1]
+
+    # default plotting attributes
+    title --> "PSIS diagnostic plot"
+    legend --> :topright
+    xguide --> "Datapoint"
+    yguide --> "Pareto shape k"
+
+    @series begin
+        seriestype := :scatter
+        marker --> 2.5
+        label := "Pk points"
+        pk
+    end
+
+    @series begin
+        seriestype := :hline
+        label := "pk = 0.5"
+        [0.5]
+    end
+
+    @series begin
+        seriestype := :hline
+        label := "pk = 0.7"
+        [0.7]
+    end
+
+    @series begin
+        seriestype := :hline
+        label := "pk = 1.0"
+        [1.0]
+    end
+end

--- a/src/pk_utilities.jl
+++ b/src/pk_utilities.jl
@@ -15,7 +15,7 @@ end
 
     # default plotting attributes
     title --> "PSIS diagnostic plot"
-    legend --> :topright
+    legend --> :topleft
     xguide --> "Datapoint"
     yguide --> "Pareto shape k"
 

--- a/src/psisloo.jl
+++ b/src/psisloo.jl
@@ -43,6 +43,3 @@ function psisloo(log_lik::AbstractArray, wcpp::Int64=20, wtrunc::Float64=3/4)
 
     return loo, loos, ks
 end
-
-export
-    psisloo

--- a/src/psisloo.jl
+++ b/src/psisloo.jl
@@ -28,7 +28,6 @@ and the PSIS estimate is likely to have large variation and some bias.
 * `loo::Real`: sum of the leave-one-out log predictive densities.
 * `loos::AbstractArray`: Individual leave-one-out log predictive density terms.* `ks::AbstractArray`: Estimated Pareto tail indeces.
 """
-# Compute LOO and standard error
 function psisloo(log_lik::AbstractArray, wcpp::Int64=20, wtrunc::Float64=3/4)
    
     # log raw weights from log_lik

--- a/src/psislw.jl
+++ b/src/psislw.jl
@@ -1,5 +1,3 @@
-using Statistics
-
 """
     psislw(lw, [wcpp, wtrunc])
 
@@ -81,6 +79,3 @@ function _psislw(lw_out::Array{Float64}, wcpp::Int64, wtrunc::Float64)
     end
     return lw_out, kss
 end
-
-export
-    psislw

--- a/src/waic.jl
+++ b/src/waic.jl
@@ -30,7 +30,3 @@ function waic( ll::AbstractArray; pointwise=false , log_lik="log_lik" , kwargs..
 
     (WAIC=waics, lppd=lpd, penalty=pD, std_err=se)
 end
-
-export
-    var2,
-    waic

--- a/src/waic.jl
+++ b/src/waic.jl
@@ -1,4 +1,3 @@
-
 var2(x) = mean(x.^2) .- mean(x)^2
 
 function waic( ll::AbstractArray; pointwise=false , log_lik="log_lik" , kwargs... )


### PR DESCRIPTION
This PR removes unnecessary dependencies (such as StanSample and StatsPlots) and reduces the dependencies to Statistics, StatsFuns and RecipeBase. This will allow us to use the package in MCMCChains without pulling in too many package, that might also not be compatible to each other and not supported on Julia 1.0.

Additionally, I fixed some docstrings but these changes can be separated if desired.